### PR TITLE
实现配置文件解析器

### DIFF
--- a/cpp_core/include/config_parser.h
+++ b/cpp_core/include/config_parser.h
@@ -2,6 +2,7 @@
 #define CONFIG_PARSER_H
 
 #include <string>
+#include <fstream>
 
 /**
  * @file config_parser.h
@@ -19,6 +20,8 @@ class ConfigParser
 {
 private:
     std::string config_file_path_; ///< 配置文件路径
+    int i_config[7];               ///< 整型配置存储,前5项目依次代表Live_min, Live_max, Breed_min, Breed_max, Vision，后2项目依次代表X, Y
+    double f_config[4];            ///< 浮点型配置存储，依次代表Death_Rate, Energy_comsumption, Restore_prob, Restore_value
 
 public:
     /**
@@ -35,13 +38,7 @@ public:
      */
     bool loadConfig();
 
-    /**
-     * @brief 保存配置到文件
-     * @return 操作是否成功
-     */
-    bool saveConfig();
-
-    /**
+       /**
      * @brief 获取整型配置值
      * @param key 配置键名
      * @param default_value 默认值
@@ -58,14 +55,6 @@ public:
     double getDouble(const std::string &key, double default_value) const;
 
     /**
-     * @brief 获取字符串配置值
-     * @param key 配置键名
-     * @param default_value 默认值
-     * @return 配置值或默认值
-     */
-    std::string getString(const std::string &key, const std::string &default_value) const;
-
-    /**
      * @brief 设置整型配置值
      * @param key 配置键名
      * @param value 配置值
@@ -78,13 +67,6 @@ public:
      * @param value 配置值
      */
     void setDouble(const std::string &key, double value);
-
-    /**
-     * @brief 设置字符串配置值
-     * @param key 配置键名
-     * @param value 配置值
-     */
-    void setString(const std::string &key, const std::string &value);
 
     /**
      * @brief 检查配置键是否存在

--- a/cpp_core/include/game_environment.h
+++ b/cpp_core/include/game_environment.h
@@ -142,5 +142,4 @@ public:
      * @param pos 细胞位置
      */
 };
-
 #endif // GAME_ENVIRONMENT_H

--- a/cpp_core/src/config_parser.cpp
+++ b/cpp_core/src/config_parser.cpp
@@ -12,61 +12,198 @@
 ConfigParser::ConfigParser(const std::string &config_file)
     : config_file_path_(config_file)
 {
-    // TODO
 }
 
 bool ConfigParser::loadConfig()
 {
-    // TODO：从配置文件加载配置
-    return false;
+    // 从配置文件加载配置
+    std::ifstream file(config_file_path_);
+    if (!file.is_open())
+    {
+        return false;
+    }
+    std::string line;
+    int lineNumber = 0;
+    while (std::getline(file, line))
+    {
+        // 跳过空行
+        if (line.empty())
+        {
+            continue;
+        }
+        // 跳过注释行
+        if (line[0] == '#')
+        {
+            continue;
+        }
+        size_t pos = line.find('=');
+        if (pos != std::string::npos)
+        {
+            std::string key = line.substr(0, pos);
+            std::string value = line.substr(pos + 1);
+            if (lineNumber < 5)
+            {
+                i_config[lineNumber] = std::stoi(value);
+            }
+            else if (lineNumber < 9)
+            {
+                f_config[lineNumber - 5] = std::stod(value);
+            }
+            else if (lineNumber == 9)
+            {
+                i_config[5] = std::stoi(value);
+            }
+            else if (lineNumber == 10)
+            {
+                i_config[6] = std::stoi(value);
+            }
+            lineNumber++;
+        }
+    }
+    return true;
 }
-
-bool ConfigParser::saveConfig()
-{
-    // TODO：保存配置到文件
-    return false;
-}
-
 int ConfigParser::getInt(const std::string &key, int default_value) const
 {
-    // TODO：获取类型为整型的配置值（例如 X, Y）
-    return default_value;
+    // 获取类型为整型的配置值
+    if (key == "Live_min")
+    {
+        return i_config[0];
+    }
+    else if (key == "Live_max")
+    {
+        return i_config[1];
+    }
+    else if (key == "Breed_min")
+    {
+        return i_config[2];
+    }
+    else if (key == "Breed_max")
+    {
+        return i_config[3];
+    }
+    else if (key == "Vision")
+    {
+        return i_config[4];
+    }
+    else if (key == "X")
+    {
+        return i_config[5];
+    }
+    else if (key == "Y")
+    {
+        return i_config[6];
+    }
+    else
+    {
+        return default_value;
+    }
 }
 
 double ConfigParser::getDouble(const std::string &key, double default_value) const
 {
-    // TODO：获取类型为浮点型的配置值（例如 Death_Rate）
-    return default_value;
-}
-
-std::string ConfigParser::getString(const std::string &key, const std::string &default_value) const
-{
-    // TODO：获取类型为字符串的配置值
-    return default_value;
+    // 获取类型为浮点型的配置值
+    if (key == "Death_Rate")
+    {
+        return f_config[0];
+    }
+    else if (key == "Energy_comsumption")
+    {
+        return f_config[1];
+    }
+    else if (key == "Restore_prob")
+    {
+        return f_config[2];
+    }
+    else if (key == "Restore_value")
+    {
+        return f_config[3];
+    }
+    else
+    {
+        return default_value;
+    }
 }
 
 void ConfigParser::setInt(const std::string &key, int value)
 {
-    // TODO：设置类型为整型的配置值
+    // 保存配置到文件
+    if (key == "Live_min")
+    {
+        i_config[0] = value;
+    }
+    else if (key == "Live_max")
+    {
+        i_config[1] = value;
+    }
+    else if (key == "Breed_min")
+    {
+        i_config[2] = value;
+    }
+    else if (key == "Breed_max")
+    {
+        i_config[3] = value;
+    }
+    else if (key == "Vision")
+    {
+        i_config[4] = value;
+    }
+    else if (key == "X")
+    {
+        i_config[5] = value;
+    }
+    else if (key == "Y")
+    {
+        i_config[6] = value;
+    }
 }
 
 void ConfigParser::setDouble(const std::string &key, double value)
 {
-    // TODO：设置类型为浮点型的配置值
-}
-
-void ConfigParser::setString(const std::string &key, const std::string &value)
-{
-    // TODO：设置类型为字符串的配置值
+    // 设置类型为浮点型的配置值
+    if (key == "Death_Rate")
+    {
+        f_config[0] = value;
+    }
+    else if (key == "Energy_comsumption")
+    {
+        f_config[1] = value;
+    }
+    else if (key == "Restore_prob")
+    {
+        f_config[2] = value;
+    }
+    else if (key == "Restore_value")
+    {
+        f_config[3] = value;
+    }
 }
 
 bool ConfigParser::hasKey(const std::string &key) const
 {
-    // TODO：检查配置键值对是否存在
-    return false;
+    // 检查配置键值对是否存在
+    if (key == "Live_min" || key == "Live_max" || key == "Breed_min" || key == "Breed_max" || key == "Vision" || key == "X" || key == "Y" ||
+        key == "Death_Rate" || key == "Energy_comsumption" || key == "Restore_prob" || key == "Restore_value")
+    {
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 void ConfigParser::printAll() const
 {
-    // TODO：输出所有配置值
+    // 输出所有配置值
+    std::cout << "Minimum number of neighbors for a cell to survive is :" << i_config[0] << std::endl;
+    std::cout << "Maximum number of neighbors for a cell to survive is :" << i_config[1] << std::endl;
+    std::cout << "Minimum number of neighbors for a cell to be born is :" << i_config[2] << std::endl;
+    std::cout << "Maximum number of neighbors for a cell to be born is :" << i_config[3] << std::endl;
+    std::cout << "Cell vision distance is :" << i_config[4] << std::endl;
+    std::cout << "Cell death probability is :" << f_config[0] << std::endl;
+    std::cout << "Cell energy consumption is :" << f_config[1] << std::endl;
+    std::cout << "Cell energy restore probability is :" << f_config[2] << std::endl;
+    std::cout << "Cell energy restore value is :" << f_config[3] << std::endl;
+    std::cout << "width of the gird is :" << i_config[5] << std::endl;
+    std::cout << "height of the gird is :" << i_config[6] << std::endl;
 }

--- a/cpp_core/src/game_environment.cpp
+++ b/cpp_core/src/game_environment.cpp
@@ -25,7 +25,8 @@ void GameEnvironment::initializeRandom(int num_cells)
 
 void GameEnvironment::update()
 {
-    // TODO:更新游戏状态
+    // TODO:若所有细胞都静止，更新游戏状态,随机增加能量，增加年龄
+    
 }
 
 void GameEnvironment::updateWithMoves(const std::vector<int> &moves)
@@ -34,6 +35,7 @@ void GameEnvironment::updateWithMoves(const std::vector<int> &moves)
     // 0~3 上下左右
     // 4~7 左上右上左下右下
     // 8 不动
+    // 随move减少能量
 }
 
 std::vector<std::vector<float>> GameEnvironment::getCellStates() const

--- a/python_bindings/pybind_wrapper.cpp
+++ b/python_bindings/pybind_wrapper.cpp
@@ -324,26 +324,26 @@ PYBIND11_MODULE(smart_life_core, m)
         .def(py::init<std::string>(), py::arg("config_file"))
         .def("load_config", &PyConfigParser::load_config,
              "Load configuration from file")
-        .def("save_config", &PyConfigParser::save_config,
-             "Save configuration to file")
+        /*.def("save_config", &PyConfigParser::save_config,
+             "Save configuration to file")*/
         .def("get_int", &PyConfigParser::get_int,
              py::arg("key"), py::arg("default_value"),
              "Get integer configuration value")
         .def("get_double", &PyConfigParser::get_double,
              py::arg("key"), py::arg("default_value"),
              "Get double configuration value")
-        .def("get_string", &PyConfigParser::get_string,
+        /*.def("get_string", &PyConfigParser::get_string,
              py::arg("key"), py::arg("default_value"),
-             "Get string configuration value")
+             "Get string configuration value")*/
         .def("set_int", &PyConfigParser::set_int,
              py::arg("key"), py::arg("value"),
              "Set integer configuration value")
         .def("set_double", &PyConfigParser::set_double,
              py::arg("key"), py::arg("value"),
              "Set double configuration value")
-        .def("set_string", &PyConfigParser::set_string,
+        /*.def("set_string", &PyConfigParser::set_string,
              py::arg("key"), py::arg("value"),
-             "Set string configuration value")
+             "Set string configuration value")*/
         .def("has_key", &PyConfigParser::has_key,
              py::arg("key"),
              "Check if configuration key exists")


### PR DESCRIPTION
1.实现了配置文件解析器的功能。
2.删去了save_config，get_string，set_string三个不必要的函数，在pybind中对这三个函数的绑定进行了注释，但是pybind中#include <pybind11/pybind11.h>
#include <pybind11/stl.h>
#include <pybind11/functional.h>
#include <pybind11/numpy.h>存在报错。